### PR TITLE
Fix a broken link to the developer manual

### DIFF
--- a/documentation/rtd/contributing.md
+++ b/documentation/rtd/contributing.md
@@ -2,6 +2,6 @@
 
 Contributions to Yggdrasil Decision Forests and Tensorflow Decision Forests are
 welcome. If you want to contribute, make sure to review the
-[developer manual](https://github.com/google/yggdrasil-decision-forests/blob/main/developer_manual.md)
+[developer manual](https://github.com/google/yggdrasil-decision-forests/blob/main/documentation/developer_manual.md)
 and
 [contribution guidelines](https://github.com/google/yggdrasil-decision-forests/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Previous one from https://ydf.readthedocs.io/en/latest/contributing.html led to 404 on Github.