### PR TITLE
Go API : categorical string values available for inspection; fixed typo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## HEAD
 
+### Fix
+
+-   Go API: fixed typo on OutOfVocabulary constant.
+
 ### Feature
 
 -   Rename experimental_analyze_model_and_dataset to analyze_model_and_dataset
 -   Add new GBT loss function `POISSON` for Poisson log likelihood.
+-   Go API: Categorical string values available for inspection.
 
 ## 1.4.0 - 2023-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## HEAD
 
-### Fix
-
--   Go API: fixed typo on OutOfVocabulary constant.
-
 ### Feature
 
 -   Rename experimental_analyze_model_and_dataset to analyze_model_and_dataset
 -   Add new GBT loss function `POISSON` for Poisson log likelihood.
 -   Go API: Categorical string values available for inspection.
+
+### Fix
+
+-   Go API: fixed typo on OutOfVocabulary constant.
 
 ## 1.4.0 - 2023-03-20
 


### PR DESCRIPTION
- Since the categorical values dictionary was previously private, it won't break anyone.
- For the fixed typo in the constant: I renamed its uses, then I recreated a constant with the typo, so there is no risk of breaking anyone.
