### PR TITLE
docs: fix scope of ydf in ydf-training JS browser example code

### DIFF
--- a/yggdrasil_decision_forests/port/javascript/training/npm/README.md
+++ b/yggdrasil_decision_forests/port/javascript/training/npm/README.md
@@ -13,10 +13,9 @@ This package supports multiple surfaces.
 <script src="./node_modules/ydf-training/dist/training.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.0/jszip.min.js"></script>
 <script>
-YDFTraining()
-    .then(ydf => fetch("http://localhost:3000/data.csv"))
-    .then( async (response) => {
-      const data = await response.text()
+YDFTraining().then(async (ydf) => {
+      const csv = await fetch("http://localhost:3000/data.csv");
+      const data = await csv.text();
       const task = "CLASSIFICATION";
       const label = "label";
       const model = new ydf.GradientBoostedTreesLearner(label, task).train(data);


### PR DESCRIPTION
See this before/after of code that had an error calling ydf.GradientBoostedTreesLearner: 
https://github.com/hchiam/learning-ydf/commit/94bcc6fc663953c7cd7b40ee94ee4c6f3aef1d78#r150940182

Here's what I saw before I made the fix to my own JavaScript code: 
<img width="500" alt="Uncaught (in promise) ReferenceError: ydf is not defined - with underlining annotations on then(ydf) and ydf.GradientBoostedTreesLearner and ydf is not defined" src="https://github.com/user-attachments/assets/1ae75c21-1271-4e0e-b2dc-c114e03b5074" />
