### PR TITLE
add recvmsg: Connection reset to isTransientError

### DIFF
--- a/yggdrasil_decision_forests/utils/distribute/implementations/grpc/grpc_common.cc
+++ b/yggdrasil_decision_forests/utils/distribute/implementations/grpc/grpc_common.cc
@@ -24,6 +24,7 @@ bool IsTransientError(const grpc::Status& status) {
   return (status.error_message() == "Socket closed" ||
           status.error_message() == "Transport closed" ||
           status.error_message() == "Connection reset by peer" ||
+          status.error_message() == "recvmsg:Connection reset by peer" ||
           status.error_message() == "Broken pipe" ||
           status.error_message() == "keepalive watchdog timeout" ||
           absl::StartsWith(status.error_message(),


### PR DESCRIPTION
Hi, we are seeing these errors in vertex ai.
The logs come from [grcp_manager.cc](https://github.com/google/yggdrasil-decision-forests/blob/412128a00dc7eb879c7bd6a24f3a17517feb54e1/yggdrasil_decision_forests/utils/distribute/implementations/grpc/grpc_manager.cc#L330) where it looks like the formatting is off. It has `recvmsg:` at the front.
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/a5391cde-7d06-4cb1-93ff-8c175e0df88e" />

This change lets it catch the error and treat it as a transient error and hopefully carry on. There might be a better way extract the underlying message, but this looks like it should work.