### PR TITLE
Flip mistaken ifndef

### DIFF
--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -787,7 +787,7 @@ void SampleProjection(const absl::Span<const int>& features,
     }
   };
 
-#ifndef NDEBUG  // Keep DCHECK_EQ from for feature : features
+#ifdef NDEBUG  // Keep DCHECK_EQ from for feature : features
   for (const auto feature : features) {
     DCHECK_EQ(data_spec.columns(feature).type(), dataset::proto::NUMERICAL);
   }


### PR DESCRIPTION
Hi team!  I found out why my Floyds implementation in PR #199 was slower than expected.

I'm mistakenly used `ifndef` instead of `ifdef`. This triggers an O(n_features) scan, which causes the slowdown. I'm seeing 6.3x with 1000 projections, 3 projection_density_factor