### PR TITLE
Add Histogram split search supports for Oblique forests

### DIFF
--- a/yggdrasil_decision_forests/learner/decision_tree/decision_tree.proto
+++ b/yggdrasil_decision_forests/learner/decision_tree/decision_tree.proto
@@ -286,8 +286,10 @@ message DecisionTreeTrainingConfig {
     // of features per projection.
     optional int32 max_num_features = 11 [default = -1];
 
-    // Controls how the split in the projection space is computed: EXACT (default)
-    // or HISTOGRAM_* (Random or Equal Width)
+    // Controls how the split in the projection space is computed: EXACT
+    // (default) or HISTOGRAM_* (Random or Equal Width). If num_candidates is
+    // not set, defaults to 63 (Random) or 255 (Equal Width); these differ from
+    // the axis-aligned numerical_split defaults.
     optional NumericalSplit projection_split = 12;
   }
 

--- a/yggdrasil_decision_forests/learner/decision_tree/decision_tree.proto
+++ b/yggdrasil_decision_forests/learner/decision_tree/decision_tree.proto
@@ -285,6 +285,10 @@ message DecisionTreeTrainingConfig {
     // otherwise prefer `projection_density_factor` for controlling the number
     // of features per projection.
     optional int32 max_num_features = 11 [default = -1];
+
+    // Controls how the split in the projection space is computed: EXACT (default)
+    // or HISTOGRAM_* (Random or Equal Width)
+    optional NumericalSplit projection_split = 12;
   }
 
   message MHLDObliqueSplit {

--- a/yggdrasil_decision_forests/learner/decision_tree/decision_tree_test.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/decision_tree_test.cc
@@ -225,8 +225,9 @@ TEST(DecisionTree, FindSplitLabelClassificationFeatureNumericalHistogram) {
   random = saved_state;
   EXPECT_EQ(FindSplitLabelClassificationFeatureNumericalHistogram(
                 selected_examples, weights, attributes, labels,
-                num_label_classes, na_replacement, min_num_obs, dt_config,
-                label_distribution, -1, &random, &best_condition)
+                num_label_classes, na_replacement, min_num_obs,
+                dt_config.numerical_split(), dt_config, label_distribution, -1,
+                &random, &best_condition)
                 .value(),
             SplitSearchResult::kBetterSplitFound);
 
@@ -241,8 +242,9 @@ TEST(DecisionTree, FindSplitLabelClassificationFeatureNumericalHistogram) {
   random = saved_state;
   EXPECT_EQ(FindSplitLabelClassificationFeatureNumericalHistogram(
                 selected_examples, weights, attributes, labels,
-                num_label_classes, na_replacement, min_num_obs, dt_config,
-                label_distribution, -1, &random, &best_condition)
+                num_label_classes, na_replacement, min_num_obs,
+                dt_config.numerical_split(), dt_config, label_distribution, -1,
+                &random, &best_condition)
                 .value(),
             SplitSearchResult::kNoBetterSplitFound);
 
@@ -250,8 +252,9 @@ TEST(DecisionTree, FindSplitLabelClassificationFeatureNumericalHistogram) {
   random = saved_state;
   EXPECT_EQ(FindSplitLabelClassificationFeatureNumericalHistogram(
                 selected_examples, weights, attributes, labels,
-                num_label_classes, na_replacement, min_num_obs, dt_config,
-                label_distribution, -1, &random, &best_condition)
+                num_label_classes, na_replacement, min_num_obs,
+                dt_config.numerical_split(), dt_config, label_distribution, -1,
+                &random, &best_condition)
                 .value(),
             SplitSearchResult::kInvalidAttribute);
 }

--- a/yggdrasil_decision_forests/learner/decision_tree/decision_tree_test.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/decision_tree_test.cc
@@ -909,8 +909,8 @@ TYPED_TEST(FindBestSplitTest, FindBestNumericalSplitHistogramForRegression) {
   EXPECT_EQ(
       FindSplitLabelRegressionFeatureNumericalHistogram<TestFixture::kWeighted>(
           selected_examples, weights, attributes, labels, na_replacement,
-          min_num_obs, dt_config, label_distribution, -1, &random,
-          &best_condition)
+          min_num_obs, dt_config.numerical_split(), dt_config,
+          label_distribution, -1, &random, &best_condition)
           .value(),
       SplitSearchResult::kBetterSplitFound);
 
@@ -931,8 +931,8 @@ TYPED_TEST(FindBestSplitTest, FindBestNumericalSplitHistogramForRegression) {
   EXPECT_EQ(
       FindSplitLabelRegressionFeatureNumericalHistogram<TestFixture::kWeighted>(
           selected_examples, weights, attributes, labels, na_replacement,
-          min_num_obs, dt_config, label_distribution, -1, &random,
-          &best_condition)
+          min_num_obs, dt_config.numerical_split(), dt_config,
+          label_distribution, -1, &random, &best_condition)
           .value(),
       SplitSearchResult::kNoBetterSplitFound);
 
@@ -941,8 +941,8 @@ TYPED_TEST(FindBestSplitTest, FindBestNumericalSplitHistogramForRegression) {
   EXPECT_EQ(
       FindSplitLabelRegressionFeatureNumericalHistogram<TestFixture::kWeighted>(
           selected_examples, weights, attributes, labels, na_replacement,
-          min_num_obs, dt_config, label_distribution, -1, &random,
-          &best_condition)
+          min_num_obs, dt_config.numerical_split(), dt_config,
+          label_distribution, -1, &random, &best_condition)
           .value(),
       SplitSearchResult::kInvalidAttribute);
 }

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -194,7 +194,7 @@ absl::StatusOr<bool> FindBestConditionSparseObliqueTemplate(
             dt_config, label_stats, dense_example_idxs, selected_weights,
             selected_labels, projection_values, internal_config,
             current_projection.front().attribute_idx, constraints,
-            monotonic_direction, best_condition, cache));
+            monotonic_direction, random, best_condition, cache));
 
     if (result == SplitSearchResult::kBetterSplitFound) {
       best_projection = current_projection;
@@ -291,6 +291,7 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
     const absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, const int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
+    utils::RandomEngine* random,
     proto::NodeCondition* condition, SplitterPerThreadCache* cache) {
   InternalTrainConfig effective_internal_config = internal_config;
   effective_internal_config.override_sorting_strategy =
@@ -325,7 +326,7 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
       ASSIGN_OR_RETURN(
           result,
           FindSplitLabelClassificationFeatureNumericalHistogram(
-              dense_example_idxs, selected_weights, projection_values, min_value, max_value,
+              dense_example_idxs, selected_weights, projection_values,
               selected_labels, label_stats.num_label_classes, na_replacement,
               min_num_obs, dt_config, label_stats.label_distribution,
               first_attribute_idx, random, condition));
@@ -391,6 +392,7 @@ EvaluateProjection<ClassificationLabelStats, std::vector<int32_t>>(
     const absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, const int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
+    utils::RandomEngine* random,
     proto::NodeCondition* condition, SplitterPerThreadCache* cache);
 
 template absl::StatusOr<SplitSearchResult>
@@ -403,6 +405,7 @@ EvaluateProjection<RegressionLabelStats, std::vector<float>>(
     const absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, const int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
+    utils::RandomEngine* random,
     proto::NodeCondition* condition, SplitterPerThreadCache* cache);
 
 template absl::StatusOr<SplitSearchResult>
@@ -415,6 +418,7 @@ EvaluateProjection<RegressionHessianLabelStats, GradientAndHessian>(
     const absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, const int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
+    utils::RandomEngine* random,
     proto::NodeCondition* condition, SplitterPerThreadCache* cache);
 
 template <typename LabelStats, typename Labels>
@@ -426,14 +430,16 @@ absl::Status EvaluateProjectionAndSetCondition(
     const std::vector<float>& selected_weights, const Labels& selected_labels,
     const absl::Span<const float> projection_values,
     const Projection& projection, const InternalTrainConfig& internal_config,
-    const int first_attribute_idx, proto::NodeCondition* condition,
+    const int first_attribute_idx, 
+    utils::RandomEngine* random,
+    proto::NodeCondition* condition,
     SplitterPerThreadCache* cache) {
   ASSIGN_OR_RETURN(
       const auto result,
       EvaluateProjection(dt_config, label_stats, dense_example_idxs,
                          selected_weights, selected_labels, projection_values,
-                         internal_config, first_attribute_idx,
-                         /*constraints=*/{}, /*monotonic_direction=*/0,
+                         internal_config, first_attribute_idx, 
+                         /*constraints=*/{}, /*monotonic_direction=*/0, random,
                          condition, cache));
 
   if (result == SplitSearchResult::kBetterSplitFound) {
@@ -478,7 +484,7 @@ absl::Status EvaluateMHLDCandidates(
       RETURN_IF_ERROR(EvaluateProjectionAndSetCondition(
           dataspec, dt_config, label_stats, dense_example_idxs,
           selected_weights, selected_labels, projection_values,
-          {{attribute_idx, 1.f}}, internal_config, attribute_idx, &condition,
+          {{attribute_idx, 1.f}}, internal_config, attribute_idx, random, &condition,
           cache));
     } else {
       // Find best projection
@@ -505,7 +511,7 @@ absl::Status EvaluateMHLDCandidates(
       RETURN_IF_ERROR(EvaluateProjectionAndSetCondition(
           dataspec, dt_config, label_stats, dense_example_idxs,
           selected_weights, selected_labels, projection_values, projection,
-          internal_config, candidate.front(), &condition, cache));
+          internal_config, candidate.front(), random, &condition, cache));
     }
   }
 

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -311,13 +311,25 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
   // Find a good split in the current_projection.
   SplitSearchResult result;
   if constexpr (is_same<LabelStats, ClassificationLabelStats>::value) {
+    if (dt_config.numerical_split().type() == proto::NumericalSplit::EXACT) {
     ASSIGN_OR_RETURN(
         result,
         FindSplitLabelClassificationFeatureNumericalCart(
-            dense_example_idxs, selected_weights, projection_values,
+            dense_example_idxs, selected_weights,
+            projection_values,
             selected_labels, label_stats.num_label_classes, na_replacement,
             min_num_obs, dt_config, label_stats.label_distribution,
             first_attribute_idx, effective_internal_config, condition, cache));
+    }
+    else {
+      ASSIGN_OR_RETURN(
+          result,
+          FindSplitLabelClassificationFeatureNumericalHistogram(
+              dense_example_idxs, selected_weights, projection_values, min_value, max_value,
+              selected_labels, label_stats.num_label_classes, na_replacement,
+              min_num_obs, dt_config, label_stats.label_distribution,
+              first_attribute_idx, random, condition));
+    }
   } else if constexpr (is_same<LabelStats,
                                RegressionHessianLabelStats>::value) {
     if (!selected_weights.empty()) {

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -194,7 +194,7 @@ absl::StatusOr<bool> FindBestConditionSparseObliqueTemplate(
             dt_config, label_stats, dense_example_idxs, selected_weights,
             selected_labels, projection_values, internal_config,
             current_projection.front().attribute_idx, constraints,
-            monotonic_direction, random, best_condition, cache));
+            monotonic_direction, best_condition, cache, random));
 
     if (result == SplitSearchResult::kBetterSplitFound) {
       best_projection = current_projection;
@@ -291,8 +291,8 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
     const absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, const int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
-    utils::RandomEngine* random,
-    proto::NodeCondition* condition, SplitterPerThreadCache* cache) {
+    proto::NodeCondition* condition, SplitterPerThreadCache* cache,
+    utils::RandomEngine* random) {
   InternalTrainConfig effective_internal_config = internal_config;
   effective_internal_config.override_sorting_strategy =
       proto::DecisionTreeTrainingConfig::Internal::SortingStrategy::
@@ -392,8 +392,8 @@ EvaluateProjection<ClassificationLabelStats, std::vector<int32_t>>(
     const absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, const int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
-    utils::RandomEngine* random,
-    proto::NodeCondition* condition, SplitterPerThreadCache* cache);
+    proto::NodeCondition* condition, SplitterPerThreadCache* cache,
+    utils::RandomEngine* random);
 
 template absl::StatusOr<SplitSearchResult>
 EvaluateProjection<RegressionLabelStats, std::vector<float>>(
@@ -405,8 +405,8 @@ EvaluateProjection<RegressionLabelStats, std::vector<float>>(
     const absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, const int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
-    utils::RandomEngine* random,
-    proto::NodeCondition* condition, SplitterPerThreadCache* cache);
+    proto::NodeCondition* condition, SplitterPerThreadCache* cache,
+    utils::RandomEngine* random);
 
 template absl::StatusOr<SplitSearchResult>
 EvaluateProjection<RegressionHessianLabelStats, GradientAndHessian>(
@@ -418,8 +418,8 @@ EvaluateProjection<RegressionHessianLabelStats, GradientAndHessian>(
     const absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, const int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
-    utils::RandomEngine* random,
-    proto::NodeCondition* condition, SplitterPerThreadCache* cache);
+    proto::NodeCondition* condition, SplitterPerThreadCache* cache,
+    utils::RandomEngine* random);
 
 template <typename LabelStats, typename Labels>
 absl::Status EvaluateProjectionAndSetCondition(
@@ -430,17 +430,15 @@ absl::Status EvaluateProjectionAndSetCondition(
     const std::vector<float>& selected_weights, const Labels& selected_labels,
     const absl::Span<const float> projection_values,
     const Projection& projection, const InternalTrainConfig& internal_config,
-    const int first_attribute_idx, 
-    utils::RandomEngine* random,
-    proto::NodeCondition* condition,
-    SplitterPerThreadCache* cache) {
+    const int first_attribute_idx, proto::NodeCondition* condition,
+    SplitterPerThreadCache* cache, utils::RandomEngine* random) {
   ASSIGN_OR_RETURN(
       const auto result,
       EvaluateProjection(dt_config, label_stats, dense_example_idxs,
                          selected_weights, selected_labels, projection_values,
-                         internal_config, first_attribute_idx, 
-                         /*constraints=*/{}, /*monotonic_direction=*/0, random,
-                         condition, cache));
+                         internal_config, first_attribute_idx,
+                         /*constraints=*/{}, /*monotonic_direction=*/0,
+                         condition, cache, random));
 
   if (result == SplitSearchResult::kBetterSplitFound) {
     RETURN_IF_ERROR(SetCondition(
@@ -484,8 +482,8 @@ absl::Status EvaluateMHLDCandidates(
       RETURN_IF_ERROR(EvaluateProjectionAndSetCondition(
           dataspec, dt_config, label_stats, dense_example_idxs,
           selected_weights, selected_labels, projection_values,
-          {{attribute_idx, 1.f}}, internal_config, attribute_idx, random, &condition,
-          cache));
+          {{attribute_idx, 1.f}}, internal_config, attribute_idx, &condition,
+          cache, random));
     } else {
       // Find best projection
       Projection projection;
@@ -511,7 +509,7 @@ absl::Status EvaluateMHLDCandidates(
       RETURN_IF_ERROR(EvaluateProjectionAndSetCondition(
           dataspec, dt_config, label_stats, dense_example_idxs,
           selected_weights, selected_labels, projection_values, projection,
-          internal_config, candidate.front(), random, &condition, cache));
+          internal_config, candidate.front(), &condition, cache, random));
     }
   }
 

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -360,22 +360,46 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
               monotonic_direction, condition, cache));
     }
   } else if constexpr (is_same<LabelStats, RegressionLabelStats>::value) {
-    if (!selected_weights.empty()) {
-      ASSIGN_OR_RETURN(
-          result,
-          FindSplitLabelRegressionFeatureNumericalCart</*weighted=*/true>(
-              dense_example_idxs, selected_weights, projection_values,
-              selected_labels, na_replacement, min_num_obs, dt_config,
-              label_stats.label_distribution, first_attribute_idx,
-              effective_internal_config, condition, cache));
+    const auto& projection_split =
+        dt_config.sparse_oblique_split().projection_split();
+    if (projection_split.type() == proto::NumericalSplit::EXACT) {
+      if (!selected_weights.empty()) {
+        ASSIGN_OR_RETURN(
+            result,
+            FindSplitLabelRegressionFeatureNumericalCart</*weighted=*/true>(
+                dense_example_idxs, selected_weights, projection_values,
+                selected_labels, na_replacement, min_num_obs, dt_config,
+                label_stats.label_distribution, first_attribute_idx,
+                effective_internal_config, condition, cache));
+      } else {
+        ASSIGN_OR_RETURN(
+            result,
+            FindSplitLabelRegressionFeatureNumericalCart</*weighted=*/false>(
+                dense_example_idxs, selected_weights, projection_values,
+                selected_labels, na_replacement, min_num_obs, dt_config,
+                label_stats.label_distribution, first_attribute_idx,
+                effective_internal_config, condition, cache));
+      }
     } else {
-      ASSIGN_OR_RETURN(
-          result,
-          FindSplitLabelRegressionFeatureNumericalCart</*weighted=*/false>(
-              dense_example_idxs, selected_weights, projection_values,
-              selected_labels, na_replacement, min_num_obs, dt_config,
-              label_stats.label_distribution, first_attribute_idx,
-              effective_internal_config, condition, cache));
+      if (!selected_weights.empty()) {
+        ASSIGN_OR_RETURN(
+            result,
+            FindSplitLabelRegressionFeatureNumericalHistogram<
+                /*weighted=*/true>(
+                dense_example_idxs, selected_weights, projection_values,
+                selected_labels, na_replacement, min_num_obs, projection_split,
+                dt_config, label_stats.label_distribution, first_attribute_idx,
+                random, condition));
+      } else {
+        ASSIGN_OR_RETURN(
+            result,
+            FindSplitLabelRegressionFeatureNumericalHistogram<
+                /*weighted=*/false>(
+                dense_example_idxs, selected_weights, projection_values,
+                selected_labels, na_replacement, min_num_obs, projection_split,
+                dt_config, label_stats.label_distribution, first_attribute_idx,
+                random, condition));
+      }
     }
   } else {
     static_assert(!is_same<LabelStats, LabelStats>::value, "Not implemented.");

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -324,18 +324,14 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
               first_attribute_idx, effective_internal_config, condition,
               cache));
     } else {
-      // The histogram splitter normally reads the split type and n.
-      // candidate thresholds from numerical_split. Apply values from
-      // projection_split
-      proto::DecisionTreeTrainingConfig histogram_dt_config = dt_config;
-      *histogram_dt_config.mutable_numerical_split() = projection_split;
       ASSIGN_OR_RETURN(
           result,
           FindSplitLabelClassificationFeatureNumericalHistogram(
               dense_example_idxs, selected_weights, projection_values,
               selected_labels, label_stats.num_label_classes, na_replacement,
-              min_num_obs, histogram_dt_config, label_stats.label_distribution,
-              first_attribute_idx, random, condition));
+              min_num_obs, projection_split, dt_config,
+              label_stats.label_distribution, first_attribute_idx, random,
+              condition));
     }
   } else if constexpr (is_same<LabelStats,
                                RegressionHessianLabelStats>::value) {

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -312,23 +312,29 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
   // Find a good split in the current_projection.
   SplitSearchResult result;
   if constexpr (is_same<LabelStats, ClassificationLabelStats>::value) {
-    if (dt_config.numerical_split().type() == proto::NumericalSplit::EXACT) {
-    ASSIGN_OR_RETURN(
-        result,
-        FindSplitLabelClassificationFeatureNumericalCart(
-            dense_example_idxs, selected_weights,
-            projection_values,
-            selected_labels, label_stats.num_label_classes, na_replacement,
-            min_num_obs, dt_config, label_stats.label_distribution,
-            first_attribute_idx, effective_internal_config, condition, cache));
-    }
-    else {
+    const auto& projection_split =
+        dt_config.sparse_oblique_split().projection_split();
+    if (projection_split.type() == proto::NumericalSplit::EXACT) {
+      ASSIGN_OR_RETURN(
+          result,
+          FindSplitLabelClassificationFeatureNumericalCart(
+              dense_example_idxs, selected_weights, projection_values,
+              selected_labels, label_stats.num_label_classes, na_replacement,
+              min_num_obs, dt_config, label_stats.label_distribution,
+              first_attribute_idx, effective_internal_config, condition,
+              cache));
+    } else {
+      // The histogram splitter normally reads the split type and n.
+      // candidate thresholds from numerical_split. Apply values from
+      // projection_split
+      proto::DecisionTreeTrainingConfig histogram_dt_config = dt_config;
+      *histogram_dt_config.mutable_numerical_split() = projection_split;
       ASSIGN_OR_RETURN(
           result,
           FindSplitLabelClassificationFeatureNumericalHistogram(
               dense_example_idxs, selected_weights, projection_values,
               selected_labels, label_stats.num_label_classes, na_replacement,
-              min_num_obs, dt_config, label_stats.label_distribution,
+              min_num_obs, histogram_dt_config, label_stats.label_distribution,
               first_attribute_idx, random, condition));
     }
   } else if constexpr (is_same<LabelStats,

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.h
@@ -148,6 +148,7 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
     absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
+    utils::RandomEngine* random,
     proto::NodeCondition* condition, SplitterPerThreadCache* cache);
 
 namespace internal {

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.h
@@ -148,8 +148,8 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
     absl::Span<const float> projection_values,
     const InternalTrainConfig& internal_config, int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
-    utils::RandomEngine* random,
-    proto::NodeCondition* condition, SplitterPerThreadCache* cache);
+    proto::NodeCondition* condition, SplitterPerThreadCache* cache,
+    utils::RandomEngine* random = nullptr);
 
 namespace internal {
 

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.h
@@ -149,7 +149,7 @@ absl::StatusOr<SplitSearchResult> EvaluateProjection(
     const InternalTrainConfig& internal_config, int first_attribute_idx,
     const NodeConstraints& constraints, int8_t monotonic_direction,
     proto::NodeCondition* condition, SplitterPerThreadCache* cache,
-    utils::RandomEngine* random = nullptr);
+    utils::RandomEngine* random);
 
 namespace internal {
 

--- a/yggdrasil_decision_forests/learner/decision_tree/training.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.cc
@@ -4377,6 +4377,27 @@ void SetDefaultHyperParameters(proto::DecisionTreeTrainingConfig* config) {
     }
   }
 
+  // Mirror the histogram num_candidates default for the oblique projection
+  // split (sparse_oblique_split.projection_split).
+  if (config->has_sparse_oblique_split() &&
+      config->sparse_oblique_split().has_projection_split() &&
+      !config->sparse_oblique_split()
+           .projection_split()
+           .has_num_candidates()) {
+    auto* ps = config->mutable_sparse_oblique_split()
+                   ->mutable_projection_split();
+    switch (ps->type()) {
+      case proto::NumericalSplit::HISTOGRAM_RANDOM:
+        ps->set_num_candidates(1);
+        break;
+      case proto::NumericalSplit::HISTOGRAM_EQUAL_WIDTH:
+        ps->set_num_candidates(255);
+        break;
+      default:
+        break;
+    }
+  }
+
   // By default, use axis aligned splits.
   if (config->split_axis_case() ==
       proto::DecisionTreeTrainingConfig::SPLIT_AXIS_NOT_SET) {

--- a/yggdrasil_decision_forests/learner/decision_tree/training.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.cc
@@ -893,16 +893,18 @@ absl::StatusOr<SplitSearchResult> FindBestConditionRegression(
                           /*weighted=*/false>(
                           selected_examples, weights, attribute_data,
                           label_stats.label_data, na_replacement, min_num_obs,
-                          dt_config, label_stats.label_distribution,
-                          attribute_idx, random, best_condition));
+                          dt_config.numerical_split(), dt_config,
+                          label_stats.label_distribution, attribute_idx,
+                          random, best_condition));
         } else {
           ASSIGN_OR_RETURN(
               result, FindSplitLabelRegressionFeatureNumericalHistogram<
                           /*weighted=*/true>(
                           selected_examples, weights, attribute_data,
                           label_stats.label_data, na_replacement, min_num_obs,
-                          dt_config, label_stats.label_distribution,
-                          attribute_idx, random, best_condition));
+                          dt_config.numerical_split(), dt_config,
+                          label_stats.label_distribution, attribute_idx,
+                          random, best_condition));
         }
       }
     } break;
@@ -2391,6 +2393,7 @@ FindSplitLabelRegressionFeatureNumericalHistogram<true>(
     const std::vector<float>& weights, absl::Span<const float> attributes,
     const std::vector<float>& labels, float na_replacement,
     UnsignedExampleIdx min_num_obs,
+    const proto::NumericalSplit& split_config,
     const proto::DecisionTreeTrainingConfig& dt_config,
     const utils::NormalDistributionDouble& label_distribution,
     int32_t attribute_idx, utils::RandomEngine* random,
@@ -2402,6 +2405,7 @@ FindSplitLabelRegressionFeatureNumericalHistogram<false>(
     const std::vector<float>& weights, absl::Span<const float> attributes,
     const std::vector<float>& labels, float na_replacement,
     UnsignedExampleIdx min_num_obs,
+    const proto::NumericalSplit& split_config,
     const proto::DecisionTreeTrainingConfig& dt_config,
     const utils::NormalDistributionDouble& label_distribution,
     int32_t attribute_idx, utils::RandomEngine* random,
@@ -2414,6 +2418,7 @@ FindSplitLabelRegressionFeatureNumericalHistogram(
     const std::vector<float>& weights, const absl::Span<const float> attributes,
     const std::vector<float>& labels, float na_replacement,
     const UnsignedExampleIdx min_num_obs,
+    const proto::NumericalSplit& split_config,
     const proto::DecisionTreeTrainingConfig& dt_config,
     const utils::NormalDistributionDouble& label_distribution,
     const int32_t attribute_idx, utils::RandomEngine* random,
@@ -2452,9 +2457,9 @@ FindSplitLabelRegressionFeatureNumericalHistogram(
   };
   ASSIGN_OR_RETURN(
       const auto bins,
-      internal::GenHistogramBins(dt_config.numerical_split().type(),
-                                 dt_config.numerical_split().num_candidates(),
-                                 attributes, min_value, max_value, random));
+      internal::GenHistogramBins(split_config.type(),
+                                 split_config.num_candidates(), attributes,
+                                 min_value, max_value, random));
 
   std::vector<CandidateSplit> candidate_splits(bins.size());
   for (int split_idx = 0; split_idx < candidate_splits.size(); split_idx++) {

--- a/yggdrasil_decision_forests/learner/decision_tree/training.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.cc
@@ -4388,7 +4388,7 @@ void SetDefaultHyperParameters(proto::DecisionTreeTrainingConfig* config) {
                    ->mutable_projection_split();
     switch (ps->type()) {
       case proto::NumericalSplit::HISTOGRAM_RANDOM:
-        ps->set_num_candidates(1);
+        ps->set_num_candidates(63);
         break;
       case proto::NumericalSplit::HISTOGRAM_EQUAL_WIDTH:
         ps->set_num_candidates(255);

--- a/yggdrasil_decision_forests/learner/decision_tree/training.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.cc
@@ -453,7 +453,8 @@ absl::StatusOr<SplitSearchResult> FindBestConditionClassification(
             result, FindSplitLabelClassificationFeatureNumericalHistogram(
                         selected_examples, weights, attribute_data->values(),
                         label_stats.label_data, label_stats.num_label_classes,
-                        na_replacement, min_num_obs, dt_config,
+                        na_replacement, min_num_obs,
+                        dt_config.numerical_split(), dt_config,
                         label_stats.label_distribution, attribute_idx, random,
                         best_condition));
       }
@@ -2021,6 +2022,7 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
     const std::vector<float>& weights, const absl::Span<const float> attributes,
     const std::vector<int32_t>& labels, const int32_t num_label_classes,
     float na_replacement, const UnsignedExampleIdx min_num_obs,
+    const proto::NumericalSplit& split_config,
     const proto::DecisionTreeTrainingConfig& dt_config,
     const utils::IntegerDistributionDouble& label_distribution,
     const int32_t attribute_idx, utils::RandomEngine* random,
@@ -2057,9 +2059,9 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
 
   ASSIGN_OR_RETURN(
       const auto bins,
-      internal::GenHistogramBins(dt_config.numerical_split().type(),
-                                 dt_config.numerical_split().num_candidates(),
-                                 attributes, min_value, max_value, random));
+      internal::GenHistogramBins(split_config.type(),
+                                 split_config.num_candidates(), attributes,
+                                 min_value, max_value, random));
 
   std::vector<CandidateSplit> candidate_splits(bins.size());
   for (int split_idx = 0; split_idx < candidate_splits.size(); split_idx++) {
@@ -2069,8 +2071,7 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
   }
 
   const bool use_equal_width_fast_path =
-      (dt_config.numerical_split().type() ==
-       proto::NumericalSplit::HISTOGRAM_EQUAL_WIDTH);
+      (split_config.type() == proto::NumericalSplit::HISTOGRAM_EQUAL_WIDTH);
 
   // Compute the split score of each threshold.
   for (const auto example_idx : selected_examples) {

--- a/yggdrasil_decision_forests/learner/decision_tree/training.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.h
@@ -681,6 +681,8 @@ FindSplitLabelRegressionFeatureNumericalHistogram(
     const std::vector<float>& weights, absl::Span<const float> attributes,
     const std::vector<float>& labels, float na_replacement,
     UnsignedExampleIdx min_num_obs,
+    // read num_candidate_splits. Both Axis-aligned and Sparse Oblique
+    const proto::NumericalSplit& split_config,
     const proto::DecisionTreeTrainingConfig& dt_config,
     const utils::NormalDistributionDouble& label_distribution,
     int32_t attribute_idx, utils::RandomEngine* random,

--- a/yggdrasil_decision_forests/learner/decision_tree/training.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.h
@@ -604,6 +604,8 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
     const std::vector<float>& weights, absl::Span<const float> attributes,
     const std::vector<int32_t>& labels, int32_t num_label_classes,
     float na_replacement, UnsignedExampleIdx min_num_obs,
+    // read num_candidate_splits. Both Axis-aligned and Sparse Oblique
+    const proto::NumericalSplit& split_config,
     const proto::DecisionTreeTrainingConfig& dt_config,
     const utils::IntegerDistributionDouble& label_distribution,
     int32_t attribute_idx, utils::RandomEngine* random,

--- a/yggdrasil_decision_forests/learner/decision_tree/training_test.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training_test.cc
@@ -461,6 +461,173 @@ TEST(SparseOblique, ClassificationMaxNumFeatures) {
             1);
 }
 
+// Trains sparse oblique with histogram split search on 100 examples forming
+// two well-separated single-class clusters along the f1=f2 diagonal
+// Any projection with a non-zero sum of weights separates the clusters,
+// so the histogram split is expected to linearly separate the two classes
+void TestSparseObliqueHistogramSplit(
+    const proto::NumericalSplit::Type projection_split_type,
+    const int num_candidates) {
+  const model::proto::TrainingConfig config;
+  model::proto::TrainingConfigLinking config_link;
+  config_link.set_label(0);
+  config_link.add_numerical_features(1);
+  config_link.add_numerical_features(2);
+
+  proto::DecisionTreeTrainingConfig dt_config;
+  auto* projection_split =
+      dt_config.mutable_sparse_oblique_split()->mutable_projection_split();
+  projection_split->set_type(projection_split_type);
+  // The num_candidates default is applied by SetDefaultHyperParameters, which
+  // is not part of this code path.
+  projection_split->set_num_candidates(num_candidates);
+  dt_config.set_min_examples(1);
+  dt_config.mutable_internal()->set_sorting_strategy(
+      proto::DecisionTreeTrainingConfig::Internal::IN_NODE);
+
+  dataset::VerticalDataset dataset;
+  ASSERT_OK_AND_ASSIGN(
+      auto label_col,
+      dataset.AddColumn("l", dataset::proto::ColumnType::CATEGORICAL));
+  label_col->mutable_categorical()->set_is_already_integerized(true);
+  label_col->mutable_categorical()->set_number_of_unique_values(3);
+  EXPECT_OK(
+      dataset.AddColumn("f1", dataset::proto::ColumnType::NUMERICAL).status());
+  EXPECT_OK(
+      dataset.AddColumn("f2", dataset::proto::ColumnType::NUMERICAL).status());
+  EXPECT_OK(dataset.CreateColumnsFromDataspec());
+
+  for (int i = 0; i < 50; i++) {
+    const std::string low = std::to_string(0.01f * i);
+    const std::string high = std::to_string(1.f + 0.01f * i);
+    dataset.AppendExample({{"l", "1"}, {"f1", low}, {"f2", low}});
+    dataset.AppendExample({{"l", "2"}, {"f1", high}, {"f2", high}});
+  }
+
+  ASSERT_OK_AND_ASSIGN(auto* label_data,
+                       dataset.MutableColumnWithCastWithStatus<
+                           dataset::VerticalDataset::CategoricalColumn>(0));
+
+  std::vector<UnsignedExampleIdx> selected_examples(dataset.nrow());
+  std::iota(selected_examples.begin(), selected_examples.end(), 0);
+  const std::vector<float> weights(selected_examples.size(), 1.f);
+
+  ClassificationLabelStats label_stats(label_data->values());
+  label_stats.num_label_classes = 3;
+  label_stats.label_distribution.SetNumClasses(3);
+  for (const auto example_idx : selected_examples) {
+    label_stats.label_distribution.Add(label_data->values()[example_idx],
+                                       weights[example_idx]);
+  }
+
+  proto::Node parent;
+  InternalTrainConfig internal_config;
+  proto::NodeCondition best_condition;
+  SplitterPerThreadCache cache;
+  utils::RandomEngine random;
+  const auto result = FindBestConditionOblique(
+                          dataset, selected_examples, weights, config,
+                          config_link, dt_config, parent, internal_config,
+                          label_stats, 20000, &best_condition, &random, &cache)
+                          .value();
+  EXPECT_TRUE(result);
+  EXPECT_EQ(best_condition.num_pos_training_examples_without_weight(), 50);
+  EXPECT_EQ(best_condition.num_training_examples_without_weight(), 100);
+  // Information gain of a perfect split between two balanced classes.
+  EXPECT_NEAR(best_condition.split_score(), 0.693, 0.001);
+}
+
+TEST(SparseOblique, ClassificationHistogramRandom) {
+  TestSparseObliqueHistogramSplit(proto::NumericalSplit::HISTOGRAM_RANDOM, 63);
+}
+
+TEST(SparseOblique, ClassificationHistogramEqualWidth) {
+  TestSparseObliqueHistogramSplit(proto::NumericalSplit::HISTOGRAM_EQUAL_WIDTH,
+                                  255);
+}
+
+// Regression counterpart of TestSparseObliqueHistogramSplit: 100 examples in
+// two well-separated clusters along the f1=f2 diagonal with labels 0 and 1.
+// Any projection with a non-zero sum of weights separates the clusters, so the
+// histogram split is expected to remove all label variance.
+void TestSparseObliqueHistogramRegressionSplit(
+    const proto::NumericalSplit::Type projection_split_type,
+    const int num_candidates) {
+  const model::proto::TrainingConfig config;
+  model::proto::TrainingConfigLinking config_link;
+  config_link.set_label(0);
+  config_link.add_numerical_features(1);
+  config_link.add_numerical_features(2);
+
+  proto::DecisionTreeTrainingConfig dt_config;
+  auto* projection_split =
+      dt_config.mutable_sparse_oblique_split()->mutable_projection_split();
+  projection_split->set_type(projection_split_type);
+  // The num_candidates default is applied by SetDefaultHyperParameters, which
+  // is not part of this code path.
+  projection_split->set_num_candidates(num_candidates);
+  dt_config.set_min_examples(1);
+  dt_config.mutable_internal()->set_sorting_strategy(
+      proto::DecisionTreeTrainingConfig::Internal::IN_NODE);
+
+  dataset::VerticalDataset dataset;
+  EXPECT_OK(
+      dataset.AddColumn("l", dataset::proto::ColumnType::NUMERICAL).status());
+  EXPECT_OK(
+      dataset.AddColumn("f1", dataset::proto::ColumnType::NUMERICAL).status());
+  EXPECT_OK(
+      dataset.AddColumn("f2", dataset::proto::ColumnType::NUMERICAL).status());
+  EXPECT_OK(dataset.CreateColumnsFromDataspec());
+
+  for (int i = 0; i < 50; i++) {
+    const std::string low = std::to_string(0.01f * i);
+    const std::string high = std::to_string(1.f + 0.01f * i);
+    dataset.AppendExample({{"l", "0"}, {"f1", low}, {"f2", low}});
+    dataset.AppendExample({{"l", "1"}, {"f1", high}, {"f2", high}});
+  }
+
+  ASSERT_OK_AND_ASSIGN(auto* label_data,
+                       dataset.MutableColumnWithCastWithStatus<
+                           dataset::VerticalDataset::NumericalColumn>(0));
+
+  std::vector<UnsignedExampleIdx> selected_examples(dataset.nrow());
+  std::iota(selected_examples.begin(), selected_examples.end(), 0);
+  const std::vector<float> weights(selected_examples.size(), 1.f);
+
+  RegressionLabelStats label_stats(label_data->values());
+  for (const auto example_idx : selected_examples) {
+    label_stats.label_distribution.Add(label_data->values()[example_idx],
+                                       weights[example_idx]);
+  }
+
+  proto::Node parent;
+  InternalTrainConfig internal_config;
+  proto::NodeCondition best_condition;
+  SplitterPerThreadCache cache;
+  utils::RandomEngine random;
+  const auto result = FindBestConditionOblique(
+                          dataset, selected_examples, weights, config,
+                          config_link, dt_config, parent, internal_config,
+                          label_stats, 20000, &best_condition, &random, &cache)
+                          .value();
+  EXPECT_TRUE(result);
+  EXPECT_EQ(best_condition.num_pos_training_examples_without_weight(), 50);
+  EXPECT_EQ(best_condition.num_training_examples_without_weight(), 100);
+  // Variance reduction of a perfect split between two balanced clusters with
+  // labels 0 and 1: the parent variance of 0.25 drops to zero.
+  EXPECT_NEAR(best_condition.split_score(), 0.25, 0.001);
+}
+
+TEST(SparseOblique, RegressionHistogramRandom) {
+  TestSparseObliqueHistogramRegressionSplit(
+      proto::NumericalSplit::HISTOGRAM_RANDOM, 63);
+}
+
+TEST(SparseOblique, RegressionHistogramEqualWidth) {
+  TestSparseObliqueHistogramRegressionSplit(
+      proto::NumericalSplit::HISTOGRAM_EQUAL_WIDTH, 255);
+}
+
 TEST(MHLDTOblique, Classification) {
   const model::proto::TrainingConfig config;
   model::proto::TrainingConfigLinking config_link;

--- a/yggdrasil_decision_forests/learner/decision_tree/vector_sequence.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/vector_sequence.cc
@@ -54,6 +54,7 @@ absl::Status TryCloserThanCondition(
     const std::vector<float>& selected_weights, const int32_t attribute_idx,
     std::vector<UnsignedExampleIdx> dense_example_idxs,
     const InternalTrainConfig& internal_config, SplitterPerThreadCache* cache,
+    utils::RandomEngine* random,
     proto::NodeCondition* condition, SplitSearchResult* result_flag,
     std::vector<float>* projections) {
   STATUS_CHECK(internal_config.vector_sequence_computer);
@@ -78,7 +79,7 @@ absl::Status TryCloserThanCondition(
         const auto local_result_flag,
         EvaluateProjection(dt_config, label_stats, dense_example_idxs,
                            selected_weights, selected_labels, local_projection,
-                           internal_config, attribute_idx, {}, 0, condition,
+                           internal_config, attribute_idx, {}, 0, random, condition,
                            cache));
 
     if (*result_flag == SplitSearchResult::kInvalidAttribute &&
@@ -113,9 +114,12 @@ absl::Status TryProjectedMoreThanCondition(
     const LabelType& label_stats, const Labels& selected_labels,
     const std::vector<float>& selected_weights, const int32_t attribute_idx,
     std::vector<UnsignedExampleIdx> dense_example_idxs,
-    const InternalTrainConfig& internal_config, SplitterPerThreadCache* cache,
+    const InternalTrainConfig& internal_config,
+    SplitterPerThreadCache* cache,
+    utils::RandomEngine* random,
     proto::NodeCondition* condition, SplitSearchResult* result_flag,
     std::vector<float>* projections) {
+
   STATUS_CHECK(internal_config.vector_sequence_computer);
   projections->resize(selected_examples.size() * num_anchors);
   RETURN_IF_ERROR(
@@ -136,7 +140,7 @@ absl::Status TryProjectedMoreThanCondition(
         const auto local_result_flag,
         EvaluateProjection(dt_config, label_stats, dense_example_idxs,
                            selected_weights, selected_labels, local_projection,
-                           internal_config, attribute_idx, {}, 0, condition,
+                           internal_config, attribute_idx, {}, 0, random, condition,
                            cache));
 
     if (*result_flag == SplitSearchResult::kInvalidAttribute &&
@@ -235,7 +239,7 @@ FindSplitAnyLabelTemplateFeatureNumericalVectorSequence(
         anchors, num_anchors, attribute, attribute_spec,
         effective_selected_examples, dt_config, label_stats,
         effective_selected_labels, effective_selected_weights, attribute_idx,
-        dense_example_idxs, internal_config, cache, effective_condition,
+        dense_example_idxs, internal_config, cache, random, effective_condition,
         &effective_result_flag, &projections);
   };
 
@@ -245,7 +249,7 @@ FindSplitAnyLabelTemplateFeatureNumericalVectorSequence(
         anchors, num_anchors, attribute, attribute_spec,
         effective_selected_examples, dt_config, label_stats,
         effective_selected_labels, effective_selected_weights, attribute_idx,
-        dense_example_idxs, internal_config, cache, effective_condition,
+        dense_example_idxs, internal_config, cache, random, effective_condition,
         &effective_result_flag, &projections);
   };
 
@@ -356,7 +360,7 @@ FindSplitAnyLabelTemplateFeatureNumericalVectorSequence(
           RETURN_IF_ERROR(TryCloserThanCondition(
               anchor, 1, attribute, attribute_spec, selected_examples,
               dt_config, label_stats, selected_labels, selected_weights,
-              attribute_idx, dense_example_idxs, internal_config, cache,
+              attribute_idx, dense_example_idxs, internal_config, cache, random,
               condition, &final_result_flag, &projections));
         } break;
 
@@ -371,7 +375,7 @@ FindSplitAnyLabelTemplateFeatureNumericalVectorSequence(
           RETURN_IF_ERROR(TryProjectedMoreThanCondition(
               anchor, 1, attribute, attribute_spec, selected_examples,
               dt_config, label_stats, selected_labels, selected_weights,
-              attribute_idx, dense_example_idxs, internal_config, cache,
+              attribute_idx, dense_example_idxs, internal_config, cache, random,
               condition, &final_result_flag, &projections));
         } break;
 

--- a/yggdrasil_decision_forests/learner/decision_tree/vector_sequence.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/vector_sequence.cc
@@ -79,8 +79,8 @@ absl::Status TryCloserThanCondition(
         const auto local_result_flag,
         EvaluateProjection(dt_config, label_stats, dense_example_idxs,
                            selected_weights, selected_labels, local_projection,
-                           internal_config, attribute_idx, {}, 0, random, condition,
-                           cache));
+                           internal_config, attribute_idx, {}, 0, condition,
+                           cache, random));
 
     if (*result_flag == SplitSearchResult::kInvalidAttribute &&
         local_result_flag == SplitSearchResult::kNoBetterSplitFound) {
@@ -140,8 +140,8 @@ absl::Status TryProjectedMoreThanCondition(
         const auto local_result_flag,
         EvaluateProjection(dt_config, label_stats, dense_example_idxs,
                            selected_weights, selected_labels, local_projection,
-                           internal_config, attribute_idx, {}, 0, random, condition,
-                           cache));
+                           internal_config, attribute_idx, {}, 0, condition,
+                           cache, random));
 
     if (*result_flag == SplitSearchResult::kInvalidAttribute &&
         local_result_flag == SplitSearchResult::kNoBetterSplitFound) {

--- a/yggdrasil_decision_forests/learner/random_forest/random_forest_test.cc
+++ b/yggdrasil_decision_forests/learner/random_forest/random_forest_test.cc
@@ -596,6 +596,19 @@ TEST_F(RandomForestOnAdult, SparseOblique) {
   EXPECT_NEAR(metric::Accuracy(evaluation_), 0.8571, 0.01);
 }
 
+TEST_F(RandomForestOnAdult, SparseObliqueHistogramRandom) {
+  auto* rf_config = train_config_.MutableExtension(
+      random_forest::proto::random_forest_config);
+  rf_config->set_winner_take_all_inference(false);
+  rf_config->mutable_decision_tree()
+      ->mutable_sparse_oblique_split()
+      ->mutable_projection_split()
+      ->set_type(decision_tree::proto::NumericalSplit::HISTOGRAM_RANDOM);
+  SetExpectedSortingStrategy(Internal::IN_NODE, &train_config_);
+  TrainAndEvaluateModel();
+  EXPECT_NEAR(metric::Accuracy(evaluation_), 0.8571, 0.01);
+}
+
 TEST_F(RandomForestOnAdult, MHLDTOblique) {
   auto* rf_config = train_config_.MutableExtension(
       random_forest::proto::random_forest_config);
@@ -679,6 +692,18 @@ TEST_F(RandomForestOnAbalone, SparseOblique) {
   auto* rf_config = train_config_.MutableExtension(
       random_forest::proto::random_forest_config);
   rf_config->mutable_decision_tree()->mutable_sparse_oblique_split();
+  SetExpectedSortingStrategy(Internal::IN_NODE, &train_config_);
+  TrainAndEvaluateModel();
+  EXPECT_NEAR(metric::RMSE(evaluation_), 2.054, 0.01);
+}
+
+TEST_F(RandomForestOnAbalone, SparseObliqueHistogramEqualWidth) {
+  auto* rf_config = train_config_.MutableExtension(
+      random_forest::proto::random_forest_config);
+  rf_config->mutable_decision_tree()
+      ->mutable_sparse_oblique_split()
+      ->mutable_projection_split()
+      ->set_type(decision_tree::proto::NumericalSplit::HISTOGRAM_EQUAL_WIDTH);
   SetExpectedSortingStrategy(Internal::IN_NODE, &train_config_);
   TrainAndEvaluateModel();
   EXPECT_NEAR(metric::RMSE(evaluation_), 2.054, 0.01);


### PR DESCRIPTION
Hi Richard, Mathieu!

This is minimal changes to add Histogramming support to Oblique forests

As for user-side toggling, we discussed w/ Richard whether decision_tree.proto:NumericalSplit should have an analogous version for only histograms. This requires further discussion