### PR TITLE
Use Highway VQSort for GenHistogramBins. 10-15% end-to-end speedup

### DIFF
--- a/yggdrasil_decision_forests/learner/decision_tree/training.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.cc
@@ -5235,7 +5235,7 @@ absl::StatusOr<std::vector<float>> GenHistogramBins(
     default:
       return absl::InvalidArgumentError("Numerical histogram not implemented");
   }
-  std::sort(candidate_splits.begin(), candidate_splits.end());
+  hwy::VQSort(candidate_splits.data(), candidate_splits.size(), hwy::SortAscending());
   return candidate_splits;
 }
 


### PR DESCRIPTION
Hi Mathieu & Richard!

A small change this time, but meaningful impact: replacing `std::sort` with Highway's VQSort in `GenHistogramBins` (used in Random Histogram Sparse Oblique)


### Diagnosis

The following are the important sub-sections of `FindSplitLabelClassificationFeatureNumericalHistogram`. Note how relatively expensive std::sort for GenHistogramBins is

<img width="842" height="1549" alt="image" src="https://github.com/user-attachments/assets/5e78246d-976a-4476-9748-de1baa0922f8" />

### Method

Simply replace `std::sort` with Highway `VQSort`.


### Results

#### End-to-end (small test, Ill run a bigger test tonight)

<img width="1073" height="310" alt="image" src="https://github.com/user-attachments/assets/25c70b3c-cbd3-48c3-8911-763f74778241" />


#### Per-function results

**42 seconds spent in std::sort -> 2.9s**

<img width="367" height="1583" alt="image" src="https://github.com/user-attachments/assets/e42a89ce-285f-4a80-bff5-8222e8ea56b4" />


[Reference Google Sheets w/ Results](https://docs.google.com/spreadsheets/d/1UEs0ohMI7TCyZL6jfnuHO4PTeC5kcSyEvyJ1vyHJaMw/edit?usp=sharing)