### PR TITLE
15% Random Forest and 30% Sparse Oblique speedup by restructuring Split Search in Random Histogram

### DIFF
--- a/yggdrasil_decision_forests/learner/decision_tree/training.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.cc
@@ -2139,8 +2139,9 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
   }
 
   const double initial_entropy = label_distribution.Entropy();
-  utils::BinaryToIntegerConfusionMatrixDouble confusion;
-  confusion.SetNumClassesIntDim(num_label_classes);
+  const int num_classes = label_distribution.NumClasses();
+  const double total_sum = label_distribution.NumObservations();
+  const double inv_total = (total_sum > 0) ? 1.0 / total_sum : 0.0;
 
   // Select the best threshold.
   bool found_split = false;
@@ -2152,11 +2153,25 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
       continue;
     }
 
-    confusion.mutable_neg()->Set(label_distribution);
-    confusion.mutable_neg()->Sub(candidate_split.pos_label_distribution);
-    confusion.mutable_pos()->Set(candidate_split.pos_label_distribution);
-
-    const double final_entropy = confusion.FinalEntropy();
+    // Inline FinalEntropy: compute both branches' weighted entropy directly
+    // from `label_distribution` and `pos_label_distribution`, avoiding the
+    // per-candidate IntegerDistribution Set/Sub copies that the previous
+    // BinaryToIntegerConfusionMatrix-based formulation required.
+    const auto& pos = candidate_split.pos_label_distribution;
+    const double pos_sum = pos.NumObservations();
+    const double neg_sum = total_sum - pos_sum;
+    double w_entropy = 0.0;
+    for (int i = 0; i < num_classes; ++i) {
+      const double pi = pos.count(i);
+      if (pi > 0 && pi < pos_sum) {
+        w_entropy -= pi * std::log(pi / pos_sum);
+      }
+      const double ni = label_distribution.count(i) - pi;
+      if (ni > 0 && ni < neg_sum) {
+        w_entropy -= ni * std::log(ni / neg_sum);
+      }
+    }
+    const double final_entropy = w_entropy * inv_total;
     const double information_gain = initial_entropy - final_entropy;
     if (information_gain > condition->split_score()) {
       condition->set_split_score(information_gain);
@@ -2165,12 +2180,10 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
       condition->set_attribute(attribute_idx);
       condition->set_num_training_examples_without_weight(
           selected_examples.size());
-      condition->set_num_training_examples_with_weight(
-          confusion.NumObservations());
+      condition->set_num_training_examples_with_weight(total_sum);
       condition->set_num_pos_training_examples_without_weight(
           candidate_split.num_positive_examples_without_weights);
-      condition->set_num_pos_training_examples_with_weight(
-          confusion.pos().NumObservations());
+      condition->set_num_pos_training_examples_with_weight(pos_sum);
       condition->set_na_value(na_replacement >= candidate_split.threshold);
       found_split = true;
     }

--- a/yggdrasil_decision_forests/learner/decision_tree/training.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.cc
@@ -2139,9 +2139,7 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
   }
 
   const double initial_entropy = label_distribution.Entropy();
-  const int num_classes = label_distribution.NumClasses();
   const double total_sum = label_distribution.NumObservations();
-  const double inv_total = (total_sum > 0) ? 1.0 / total_sum : 0.0;
 
   // Select the best threshold.
   bool found_split = false;
@@ -2153,25 +2151,12 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
       continue;
     }
 
-    // Inline FinalEntropy: compute both branches' weighted entropy directly
-    // from `label_distribution` and `pos_label_distribution`, avoiding the
-    // per-candidate IntegerDistribution Set/Sub copies that the previous
-    // BinaryToIntegerConfusionMatrix-based formulation required.
+    // Final entropy from the node's label distribution and the candidate's
+    // positive-branch distribution, without materializing a per-candidate
+    // BinaryToIntegerConfusionMatrix (two IntegerDistribution copies).
     const auto& pos = candidate_split.pos_label_distribution;
-    const double pos_sum = pos.NumObservations();
-    const double neg_sum = total_sum - pos_sum;
-    double w_entropy = 0.0;
-    for (int i = 0; i < num_classes; ++i) {
-      const double pi = pos.count(i);
-      if (pi > 0 && pi < pos_sum) {
-        w_entropy -= pi * std::log(pi / pos_sum);
-      }
-      const double ni = label_distribution.count(i) - pi;
-      if (ni > 0 && ni < neg_sum) {
-        w_entropy -= ni * std::log(ni / neg_sum);
-      }
-    }
-    const double final_entropy = w_entropy * inv_total;
+    const double final_entropy = utils::BinaryToIntegerConfusionMatrixDouble::
+        FinalEntropyFromTotalAndPos(label_distribution, pos);
     const double information_gain = initial_entropy - final_entropy;
     if (information_gain > condition->split_score()) {
       condition->set_split_score(information_gain);
@@ -2183,7 +2168,8 @@ FindSplitLabelClassificationFeatureNumericalHistogram(
       condition->set_num_training_examples_with_weight(total_sum);
       condition->set_num_pos_training_examples_without_weight(
           candidate_split.num_positive_examples_without_weights);
-      condition->set_num_pos_training_examples_with_weight(pos_sum);
+      condition->set_num_pos_training_examples_with_weight(
+          pos.NumObservations());
       condition->set_na_value(na_replacement >= candidate_split.threshold);
       found_split = true;
     }

--- a/yggdrasil_decision_forests/utils/distribution.h
+++ b/yggdrasil_decision_forests/utils/distribution.h
@@ -322,6 +322,19 @@ class BinaryToIntegerConfusionMatrix {
   double InitEntropy() const;
   double FinalEntropy() const;
 
+  // Binary split entropy computed directly from the two
+  // distributions.
+  //
+  // Equivalent to:
+  //   BinaryToIntegerConfusionMatrix<T> m;
+  //   m.mutable_neg()->Set(total); m.mutable_neg()->Sub(pos);
+  //   m.mutable_pos()->Set(pos);
+  //   m.FinalEntropy();
+  // but ~20% faster end-to-end on GCC and ICX compilers.
+  // Possibly bcs. it avoids the per-call allocation and copy of the distributions.
+  static double FinalEntropyFromTotalAndPos(const IntegerDistribution<T>& total,
+                                            const IntegerDistribution<T>& pos);
+
   // Set the number of classes i.e. the possible values are [0, NumClasses() [.
   void SetNumClassesIntDim(int int_dim);
 
@@ -1006,6 +1019,34 @@ double BinaryToIntegerConfusionMatrix<T>::FinalEntropy() const {
   if (sum == 0) return 0;
   const double p_neg = static_cast<double>(neg().NumObservations()) / sum;
   return neg().Entropy() * p_neg + pos().Entropy() * (1 - p_neg);
+}
+
+template <typename T>
+double BinaryToIntegerConfusionMatrix<T>::FinalEntropyFromTotalAndPos(
+    const IntegerDistribution<T>& total, const IntegerDistribution<T>& pos) {
+  DCHECK_EQ(total.NumClasses(), pos.NumClasses());
+  const double total_sum = static_cast<double>(total.NumObservations());
+  if (total_sum <= 0) return 0.;
+  const double pos_sum = static_cast<double>(pos.NumObservations());
+  const double neg_sum = total_sum - pos_sum;
+  const int num_classes = total.NumClasses();
+  // Sum of "-count * log(count / branch_sum)" over both branches, i.e. the
+  // branch entropies weighted by the branch sizes. Dividing by "total_sum"
+  // at the end gives the size-weighted average of the two branch entropies.
+  double weighted_entropy = 0.;
+  for (int i = 0; i < num_classes; ++i) {
+    const double pos_count = static_cast<double>(pos.count(i));
+    if (pos_count > 0 && pos_count < pos_sum) {
+      weighted_entropy -= pos_count * std::log(pos_count / pos_sum);
+    }
+    const double neg_count =
+        static_cast<double>(total.count(i)) - pos_count;
+    if (neg_count > 0 && neg_count < neg_sum) {
+      weighted_entropy -= neg_count * std::log(neg_count / neg_sum);
+    }
+  }
+  const double inv_total = 1. / total_sum;
+  return weighted_entropy * inv_total;
 }
 
 }  // namespace utils

--- a/yggdrasil_decision_forests/utils/distribution_test.cc
+++ b/yggdrasil_decision_forests/utils/distribution_test.cc
@@ -303,6 +303,75 @@ TEST(Distribution, BinaryToIntegerConfusionMatrixAdd) {
   EXPECT_NEAR(conf.FinalEntropy(), 0.462098, 0.0001);
 }
 
+TEST(Distribution, BinaryToIntegerConfusionMatrixFinalEntropyFromTotalAndPosDouble) {
+  IntegerDistributionDouble total;
+  IntegerDistributionDouble pos;
+  total.SetNumClasses(4);
+  pos.SetNumClasses(4);
+
+  total.Add(1, 3.);
+  total.Add(2, 2.);
+  total.Add(3, 1.);
+  pos.Add(1, 1.);
+  pos.Add(2, 2.);
+
+  // (entropy(c(1,2)) * 3 + entropy(c(2,1)) * 3) / 6 in R.
+  EXPECT_NEAR(BinaryToIntegerConfusionMatrixDouble::FinalEntropyFromTotalAndPos(
+                  total, pos),
+              0.636514, 0.0001);
+}
+
+// Check FinalEntropyFromTotalAndPos is equivalent to FinalEntropy
+TEST(Distribution,
+     BinaryToIntegerConfusionMatrixFinalEntropyFromTotalAndPosMatchesFinalEntropy) {
+  IntegerDistributionDouble total;
+  IntegerDistributionDouble pos;
+  total.SetNumClasses(4);
+  pos.SetNumClasses(4);
+
+  total.Add(1, 3.);
+  total.Add(2, 2.);
+  total.Add(3, 1.);
+  pos.Add(1, 1.);
+  pos.Add(2, 2.);
+
+  BinaryToIntegerConfusionMatrixDouble conf;
+  conf.SetNumClassesIntDim(4);
+  conf.mutable_neg()->Set(total);
+  conf.mutable_neg()->Sub(pos);
+  conf.mutable_pos()->Set(pos);
+
+  EXPECT_NEAR(BinaryToIntegerConfusionMatrixDouble::FinalEntropyFromTotalAndPos(
+                  total, pos),
+              conf.FinalEntropy(), 1e-12);
+}
+
+TEST(Distribution, BinaryToIntegerConfusionMatrixFinalEntropyFromTotalAndPosDegenerate) {
+  IntegerDistributionDouble total;
+  IntegerDistributionDouble empty;
+  total.SetNumClasses(4);
+  empty.SetNumClasses(4);
+
+  total.Add(1, 3.);
+  total.Add(2, 2.);
+  total.Add(3, 1.);
+
+  // All examples in the negative branch: entropy(c(3,2,1)) in R.
+  EXPECT_NEAR(BinaryToIntegerConfusionMatrixDouble::FinalEntropyFromTotalAndPos(
+                  total, empty),
+              1.011404, 0.0001);
+
+  // All examples in the positive branch: entropy(c(3,2,1)) in R.
+  EXPECT_NEAR(BinaryToIntegerConfusionMatrixDouble::FinalEntropyFromTotalAndPos(
+                  total, total),
+              1.011404, 0.0001);
+
+  // No examples.
+  EXPECT_EQ(BinaryToIntegerConfusionMatrixDouble::FinalEntropyFromTotalAndPos(
+                empty, empty),
+            0.);
+}
+
 TEST(Distribution, IntegersConfusionMatrix_AppendTextReport) {
   IntegersConfusionMatrixDouble confusion;
   confusion.SetSize(4, 4);


### PR DESCRIPTION
Hi again Richard & Mathieu!

More significant and interesting speedup: **pulling invariants out of the Random Histogram's Scan candidate thresholds loop gives 15% speedup in Axis-aligned RF (Random Hist) and 30% in Sparse Oblique across many datasets**, and accuracy is identical save for floating-point differences (across 35 datasets x 10 different seeds).

<img width="1210" height="727" alt="image" src="https://github.com/user-attachments/assets/31d6b724-354c-46de-b492-951d45a79a16" />

Per-function speedup:

In my CHRONO times below, Scanning Thresholds is only 20% of the overall time, yet the end-to-end speedup is 30%+. This suggests my CHRONO has overhead that distorts the underlying relative weights of functions.

<img width="434" height="1577" alt="image" src="https://github.com/user-attachments/assets/83831b79-21b7-4c65-a5ce-4bb880b3edfa" />


[Full runtime tests + Accuracy](https://docs.google.com/spreadsheets/d/1PtR-I_sIF8u6LjuE69Ttt6PXBf57KYcsfkEc9Xw6XTw/edit?usp=sharing)
