### PR TITLE
3x faster SPORF on high dimensional data by Caching ProjectionEvaluator()

### DIFF
--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -65,11 +65,10 @@ namespace internal {
 
 // Per-thread reusable ProjectionEvaluator. The evaluator only depends on
 // (dataset, numerical_features); under GLOBAL_IMPUTATION both are constant
-// across every node of every tree, so rebuilding its per-attribute pointer
-// tables per node is pure setup waste. RANDOM_LOCAL_IMPUTATION trains each node
-// on a fresh per-node dataset whose address could alias a freed one -> never
-// cache there (reusable_dataset=false always rebuilds and clears the identity
-// keys).
+// across every node of every tree.
+// RANDOM_LOCAL_IMPUTATION trains each node on a fresh per-node dataset whose address
+// could alias a freed one -> can't cache there (reusable_dataset=false always 
+// rebuilds and clears the identity keys).
 class ProjectionEvaluatorCache {
  public:
   ProjectionEvaluator& Get(
@@ -103,7 +102,7 @@ class ProjectionEvaluatorCache {
  private:
   std::optional<ProjectionEvaluator> evaluator_;
   const dataset::VerticalDataset* train_dataset_ = nullptr;
-  int64_t nrow_ = -1;
+  SignedExampleIdx nrow_ = -1;
   std::vector<int32_t> numerical_features_;
 };
 

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <numeric>
 #include <optional>
 #include <random>
@@ -57,6 +58,74 @@ using std::is_same;
 using Projection = internal::Projection;
 using ProjectionEvaluator = internal::ProjectionEvaluator;
 using LDACache = internal::LDACache;
+
+}  // namespace
+
+namespace internal {
+
+// Per-thread reusable ProjectionEvaluator. The evaluator only depends on
+// (dataset, numerical_features); under GLOBAL_IMPUTATION both are constant
+// across every node of every tree, so rebuilding its per-attribute pointer
+// tables per node is pure setup waste. RANDOM_LOCAL_IMPUTATION trains each node
+// on a fresh per-node dataset whose address could alias a freed one -> never
+// cache there (reusable_dataset=false always rebuilds and clears the identity
+// keys).
+class ProjectionEvaluatorCache {
+ public:
+  ProjectionEvaluator& Get(
+      const dataset::VerticalDataset& train_dataset,
+      const google::protobuf::RepeatedField<int32_t>& numerical_features,
+      const bool reusable_dataset) {
+    const bool cache_hit =
+        reusable_dataset && evaluator_.has_value() &&
+        train_dataset_ == &train_dataset &&
+        nrow_ == static_cast<int64_t>(train_dataset.nrow()) &&
+        numerical_features_.size() ==
+            static_cast<size_t>(numerical_features.size()) &&
+        std::equal(numerical_features_.begin(), numerical_features_.end(),
+                   numerical_features.begin());
+    if (!cache_hit) {
+      evaluator_.emplace(train_dataset, numerical_features);
+      if (reusable_dataset) {
+        train_dataset_ = &train_dataset;
+        nrow_ = static_cast<int64_t>(train_dataset.nrow());
+        numerical_features_.assign(numerical_features.begin(),
+                                   numerical_features.end());
+      } else {
+        train_dataset_ = nullptr;
+        nrow_ = -1;
+        numerical_features_.clear();
+      }
+    }
+    return *evaluator_;
+  }
+
+ private:
+  std::optional<ProjectionEvaluator> evaluator_;
+  const dataset::VerticalDataset* train_dataset_ = nullptr;
+  int64_t nrow_ = -1;
+  std::vector<int32_t> numerical_features_;
+};
+
+}  // namespace internal
+
+namespace {
+
+ProjectionEvaluator& GetProjectionEvaluator(
+    const dataset::VerticalDataset& train_dataset,
+    const model::proto::TrainingConfigLinking& config_link,
+    const proto::DecisionTreeTrainingConfig& dt_config,
+    SplitterPerThreadCache* cache) {
+  if (cache->projection_evaluator_cache == nullptr) {
+    cache->projection_evaluator_cache =
+        std::make_shared<internal::ProjectionEvaluatorCache>();
+  }
+  const bool reusable_dataset =
+      dt_config.missing_value_policy() ==
+      proto::DecisionTreeTrainingConfig::GLOBAL_IMPUTATION;
+  return cache->projection_evaluator_cache->Get(
+      train_dataset, config_link.numerical_features(), reusable_dataset);
+}
 
 }  // namespace
 
@@ -164,8 +233,8 @@ absl::StatusOr<bool> FindBestConditionSparseObliqueTemplate(
   Projection current_projection;
   auto& projection_values = cache->projection_values;
 
-  ProjectionEvaluator projection_evaluator(train_dataset,
-                                           config_link.numerical_features());
+  ProjectionEvaluator& projection_evaluator =
+      GetProjectionEvaluator(train_dataset, config_link, dt_config, cache);
 
   // TODO: Cache.
   const auto selected_labels = ExtractLabels(label_stats, selected_examples);
@@ -545,8 +614,8 @@ absl::StatusOr<bool> FindBestConditionMHLDObliqueTemplate(
     return false;
   }
 
-  ProjectionEvaluator projection_evaluator(train_dataset,
-                                           config_link.numerical_features());
+  ProjectionEvaluator& projection_evaluator =
+      GetProjectionEvaluator(train_dataset, config_link, dt_config, cache);
 
   // TODO: Cache.
   const auto selected_labels = ExtractLabels(label_stats, selected_examples);

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.cc
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <numeric>
 #include <optional>
 #include <random>
@@ -59,71 +58,18 @@ using Projection = internal::Projection;
 using ProjectionEvaluator = internal::ProjectionEvaluator;
 using LDACache = internal::LDACache;
 
-}  // namespace
-
-namespace internal {
-
-// Per-thread reusable ProjectionEvaluator. The evaluator only depends on
-// (dataset, numerical_features); under GLOBAL_IMPUTATION both are constant
-// across every node of every tree.
-// RANDOM_LOCAL_IMPUTATION trains each node on a fresh per-node dataset whose address
-// could alias a freed one -> can't cache there (reusable_dataset=false always 
-// rebuilds and clears the identity keys).
-class ProjectionEvaluatorCache {
- public:
-  ProjectionEvaluator& Get(
-      const dataset::VerticalDataset& train_dataset,
-      const google::protobuf::RepeatedField<int32_t>& numerical_features,
-      const bool reusable_dataset) {
-    const bool cache_hit =
-        reusable_dataset && evaluator_.has_value() &&
-        train_dataset_ == &train_dataset &&
-        nrow_ == static_cast<int64_t>(train_dataset.nrow()) &&
-        numerical_features_.size() ==
-            static_cast<size_t>(numerical_features.size()) &&
-        std::equal(numerical_features_.begin(), numerical_features_.end(),
-                   numerical_features.begin());
-    if (!cache_hit) {
-      evaluator_.emplace(train_dataset, numerical_features);
-      if (reusable_dataset) {
-        train_dataset_ = &train_dataset;
-        nrow_ = static_cast<int64_t>(train_dataset.nrow());
-        numerical_features_.assign(numerical_features.begin(),
-                                   numerical_features.end());
-      } else {
-        train_dataset_ = nullptr;
-        nrow_ = -1;
-        numerical_features_.clear();
-      }
-    }
-    return *evaluator_;
-  }
-
- private:
-  std::optional<ProjectionEvaluator> evaluator_;
-  const dataset::VerticalDataset* train_dataset_ = nullptr;
-  SignedExampleIdx nrow_ = -1;
-  std::vector<int32_t> numerical_features_;
-};
-
-}  // namespace internal
-
-namespace {
-
-ProjectionEvaluator& GetProjectionEvaluator(
+// Returns the tree-wide projection evaluator provided by internal_config
+// If none, builds a node-local evaluator and returns it.
+const ProjectionEvaluator& GetProjectionEvaluator(
     const dataset::VerticalDataset& train_dataset,
     const model::proto::TrainingConfigLinking& config_link,
-    const proto::DecisionTreeTrainingConfig& dt_config,
-    SplitterPerThreadCache* cache) {
-  if (cache->projection_evaluator_cache == nullptr) {
-    cache->projection_evaluator_cache =
-        std::make_shared<internal::ProjectionEvaluatorCache>();
+    const InternalTrainConfig& internal_config,
+    std::optional<ProjectionEvaluator>* local_evaluator) {
+  if (internal_config.projection_evaluator != nullptr) {
+    return *internal_config.projection_evaluator;
   }
-  const bool reusable_dataset =
-      dt_config.missing_value_policy() ==
-      proto::DecisionTreeTrainingConfig::GLOBAL_IMPUTATION;
-  return cache->projection_evaluator_cache->Get(
-      train_dataset, config_link.numerical_features(), reusable_dataset);
+  local_evaluator->emplace(train_dataset, config_link.numerical_features());
+  return **local_evaluator;
 }
 
 }  // namespace
@@ -232,8 +178,10 @@ absl::StatusOr<bool> FindBestConditionSparseObliqueTemplate(
   Projection current_projection;
   auto& projection_values = cache->projection_values;
 
-  ProjectionEvaluator& projection_evaluator =
-      GetProjectionEvaluator(train_dataset, config_link, dt_config, cache);
+  std::optional<ProjectionEvaluator> local_projection_evaluator;
+  const ProjectionEvaluator& projection_evaluator =
+      GetProjectionEvaluator(train_dataset, config_link, internal_config,
+                             &local_projection_evaluator);
 
   // TODO: Cache.
   const auto selected_labels = ExtractLabels(label_stats, selected_examples);
@@ -613,8 +561,10 @@ absl::StatusOr<bool> FindBestConditionMHLDObliqueTemplate(
     return false;
   }
 
-  ProjectionEvaluator& projection_evaluator =
-      GetProjectionEvaluator(train_dataset, config_link, dt_config, cache);
+  std::optional<ProjectionEvaluator> local_projection_evaluator;
+  const ProjectionEvaluator& projection_evaluator =
+      GetProjectionEvaluator(train_dataset, config_link, internal_config,
+                             &local_projection_evaluator);
 
   // TODO: Cache.
   const auto selected_labels = ExtractLabels(label_stats, selected_examples);

--- a/yggdrasil_decision_forests/learner/decision_tree/oblique.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/oblique.h
@@ -175,6 +175,19 @@ class ProjectionEvaluator {
   ProjectionEvaluator(const dataset::VerticalDataset& train_dataset,
                       const google::protobuf::RepeatedField<int32_t>& numerical_features);
 
+  // Whether an evaluator can be cached i.e. built once per tree (by
+  // DecisionTreeTrain) and shared. The evaluator holds pointers into
+  // the dataset's columns, so the dataset must not change.
+  // Currently only guaranteed with GLOBAL_IMPUTATION (default policy).
+  // TODO: Likely also safe with LOCAL_IMPUTATION: verify
+  static bool CanBeCached(const proto::DecisionTreeTrainingConfig& dt_config) {
+    const bool use_oblique_splits = dt_config.has_sparse_oblique_split() ||
+                                    dt_config.has_mhld_oblique_split();
+    return use_oblique_splits &&
+           dt_config.missing_value_policy() ==
+               proto::DecisionTreeTrainingConfig::GLOBAL_IMPUTATION;
+  }
+
   // Evaluates a projection of a set of selected examples.
   //
   // "values", the output variable, contains "selected_examples.size()" values.

--- a/yggdrasil_decision_forests/learner/decision_tree/training.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.cc
@@ -4834,8 +4834,28 @@ absl::Status DecisionTreeTrain(
                                      absl::MakeSpan(leaf_examples.value()))
                                : std::nullopt;
 
+  const bool use_oblique_splits = dt_config.has_sparse_oblique_split() ||
+                                  dt_config.has_mhld_oblique_split();
+
+  std::optional<internal::ProjectionEvaluator> projection_evaluator;
+  InternalTrainConfig effective_internal_config = internal_config;
+
+  // If oblique splits are enabled, build the projection evaluator once for the
+  // entire tree. Without it, oblique splitters each build a node-local evaluator, each costing O(n. features)
+  // This is not possible with RANDOM_LOCAL_IMPUTATION, where NodeTrain() calls the
+  // splitters with a freshly generated per-node dataset
+  if (use_oblique_splits &&
+      dt_config.missing_value_policy() !=
+          proto::DecisionTreeTrainingConfig::RANDOM_LOCAL_IMPUTATION &&
+      internal_config.projection_evaluator == nullptr) {
+    projection_evaluator.emplace(train_dataset,
+                                 config_link.numerical_features());
+    effective_internal_config.projection_evaluator = &*projection_evaluator;
+  }
+
   return DecisionTreeCoreTrain(train_dataset, config, config_link, dt_config,
-                               deployment, weights, random, internal_config, dt,
+                               deployment, weights, random,
+                               effective_internal_config, dt,
                                absl::MakeSpan(working_selected_examples),
                                leaf_example_span);
 }

--- a/yggdrasil_decision_forests/learner/decision_tree/training.cc
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.cc
@@ -4834,20 +4834,14 @@ absl::Status DecisionTreeTrain(
                                      absl::MakeSpan(leaf_examples.value()))
                                : std::nullopt;
 
-  const bool use_oblique_splits = dt_config.has_sparse_oblique_split() ||
-                                  dt_config.has_mhld_oblique_split();
-
   std::optional<internal::ProjectionEvaluator> projection_evaluator;
   InternalTrainConfig effective_internal_config = internal_config;
 
   // If oblique splits are enabled, build the projection evaluator once for the
-  // entire tree. Without it, oblique splitters each build a node-local evaluator, each costing O(n. features)
-  // This is not possible with RANDOM_LOCAL_IMPUTATION, where NodeTrain() calls the
-  // splitters with a freshly generated per-node dataset
-  if (use_oblique_splits &&
-      dt_config.missing_value_policy() !=
-          proto::DecisionTreeTrainingConfig::RANDOM_LOCAL_IMPUTATION &&
-      internal_config.projection_evaluator == nullptr) {
+  // entire tree. Without it, oblique splitters each build a node-local
+  // evaluator, each costing O(number of features).
+  if (internal_config.projection_evaluator == nullptr &&
+      internal::ProjectionEvaluator::CanBeCached(dt_config)) {
     projection_evaluator.emplace(train_dataset,
                                  config_link.numerical_features());
     effective_internal_config.projection_evaluator = &*projection_evaluator;

--- a/yggdrasil_decision_forests/learner/decision_tree/training.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.h
@@ -141,6 +141,13 @@ struct SplitterPerThreadCache {
 
   std::vector<int> numerical_features;
   std::vector<float> projection_values;
+  // Ownership is not shared: each SplitterPerThreadCache owns its own
+  // instance. A shared_ptr is used because ProjectionEvaluatorCache is only
+  // forward-declared here: it's defined in oblique.cc and cannot live in
+  // oblique.h, which includes this header.
+  // shared_ptr's deleter is type-erased at make_shared() time,
+  // so translation units that destroy this struct without seeing the 
+  // definition still compile, which unique_ptr's default deleter would not allow.
   std::shared_ptr<internal::ProjectionEvaluatorCache>
       projection_evaluator_cache;
 

--- a/yggdrasil_decision_forests/learner/decision_tree/training.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.h
@@ -51,6 +51,8 @@
 namespace yggdrasil_decision_forests::model::decision_tree {
 
 namespace internal {
+class ProjectionEvaluatorCache;
+
 struct NodeAndExamples {
   // The current node
   NodeWithChildren* node;
@@ -139,6 +141,8 @@ struct SplitterPerThreadCache {
 
   std::vector<int> numerical_features;
   std::vector<float> projection_values;
+  std::shared_ptr<internal::ProjectionEvaluatorCache>
+      projection_evaluator_cache;
 
   std::vector<int> catset_candidate_attributes_list;
   std::vector<std::vector<UnsignedExampleIdx>> catset_examples_by_candidate;

--- a/yggdrasil_decision_forests/learner/decision_tree/training.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.h
@@ -51,7 +51,7 @@
 namespace yggdrasil_decision_forests::model::decision_tree {
 
 namespace internal {
-class ProjectionEvaluatorCache;
+class ProjectionEvaluator;
 
 struct NodeAndExamples {
   // The current node
@@ -141,15 +141,6 @@ struct SplitterPerThreadCache {
 
   std::vector<int> numerical_features;
   std::vector<float> projection_values;
-  // Ownership is not shared: each SplitterPerThreadCache owns its own
-  // instance. A shared_ptr is used because ProjectionEvaluatorCache is only
-  // forward-declared here: it's defined in oblique.cc and cannot live in
-  // oblique.h, which includes this header.
-  // shared_ptr's deleter is type-erased at make_shared() time,
-  // so translation units that destroy this struct without seeing the 
-  // definition still compile, which unique_ptr's default deleter would not allow.
-  std::shared_ptr<internal::ProjectionEvaluatorCache>
-      projection_evaluator_cache;
 
   std::vector<int> catset_candidate_attributes_list;
   std::vector<std::vector<UnsignedExampleIdx>> catset_examples_by_candidate;
@@ -342,6 +333,18 @@ struct InternalTrainConfig {
   // Non owning pointer to pre-processing information.
   // Depending on the decision tree configuration this field might be required.
   const Preprocessing* preprocessing = nullptr;
+
+  // Non owning pointer to a projection evaluator shared by all the oblique
+  // split searches of a tree. Set by DecisionTreeTrain when oblique splits
+  // are enabled. If null, oblique splitters each build a per-node evaluator
+  // instead (cost: O(number of features) each).
+  //
+  // Evaluator holds pointers into the columns of the dataset it was built
+  // on, so it can only be used with that same dataset. This works for all
+  // missing policies except RANDOM_LOCAL_IMPUTATION, which calls the splitter
+  // with a nodewise copy with randomly imputed missing values.
+  // This is kept null in that case, triggering per-node construction
+  const internal::ProjectionEvaluator* projection_evaluator = nullptr;
 
   decision_tree::gpu::VectorSequenceComputer* vector_sequence_computer =
       nullptr;

--- a/yggdrasil_decision_forests/learner/decision_tree/training.h
+++ b/yggdrasil_decision_forests/learner/decision_tree/training.h
@@ -334,16 +334,10 @@ struct InternalTrainConfig {
   // Depending on the decision tree configuration this field might be required.
   const Preprocessing* preprocessing = nullptr;
 
-  // Non owning pointer to a projection evaluator shared by all the oblique
-  // split searches of a tree. Set by DecisionTreeTrain when oblique splits
-  // are enabled. If null, oblique splitters each build a per-node evaluator
-  // instead (cost: O(number of features) each).
-  //
-  // Evaluator holds pointers into the columns of the dataset it was built
-  // on, so it can only be used with that same dataset. This works for all
-  // missing policies except RANDOM_LOCAL_IMPUTATION, which calls the splitter
-  // with a nodewise copy with randomly imputed missing values.
-  // This is kept null in that case, triggering per-node construction
+  // Non-owning pointer to a projection evaluator shared by all the oblique
+  // split searches of a tree. Set by DecisionTreeTrain when
+  // "ProjectionEvaluator::CanBeCached" is true. If null, oblique splitters
+  // each build a per-node evaluator instead (cost: O(number of features)
   const internal::ProjectionEvaluator* projection_evaluator = nullptr;
 
   decision_tree::gpu::VectorSequenceComputer* vector_sequence_computer =


### PR DESCRIPTION
Hi Richard & Mathieu! 

A big contribution! I implemented caching ProjectionEvaluator instead of creating it per-node. This is the object that is used for ApplyProjection. 

-  **Massive benefit for Sparse Oblique RF**: Up to 3x on high dimensional data, 20% on mid-range and 10% on skinny 
-  Modest benefit for Sparse Oblique GBT : ~5%

<img width="836" height="152" alt="Screenshot 2026-07-07 at 11 06 07" src="https://github.com/user-attachments/assets/b83de9a5-c785-49fe-a366-ce4f24ac3acc" />

<img width="471" height="291" alt="Benefit is in FOSetup" src="https://github.com/user-attachments/assets/84960d7c-7105-41dc-a3db-7e6c170de327" />


``ProjectionEvaluator`` does an $$O(F)$$ per-attribute pointer-table fill on every node of every tree. But the evaluator only depends on (dataset, numerical_features), which are constant across all nodes under GLOBAL_IMPUTATION.

**Fix:** Add a per-thread ``ProjectionEvaluatorCache`` that reuses the evaluator when the dataset identity + numerical feature set match.


As always, detailed experiments file [located here](https://docs.google.com/spreadsheets/d/1hNkemfRMEDgU9Nm8JGB7fHLE-6xsw7mxwoGYGpCb2eY/edit?usp=sharing)