### PR TITLE
Escape column names in ColumnGuide regex patterns

### DIFF
--- a/yggdrasil_decision_forests/port/python/ydf/dataset/dataspec.py
+++ b/yggdrasil_decision_forests/port/python/ydf/dataset/dataspec.py
@@ -16,6 +16,7 @@
 
 import dataclasses
 import enum
+import re
 from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -411,7 +412,7 @@ class Column(object):
 
     guide = ds_pb.ColumnGuide(
         # Only match the exact name
-        column_name_pattern=f"^{self.name}$",
+        column_name_pattern=f"^{re.escape(self.name)}$",
         categorial=categorical_guide,
         discretized_numerical=ds_pb.DiscretizedNumericalGuide(
             maximum_num_bins=self.num_discretized_numerical_bins

--- a/yggdrasil_decision_forests/port/python/ydf/dataset/dataspec_test.py
+++ b/yggdrasil_decision_forests/port/python/ydf/dataset/dataspec_test.py
@@ -198,6 +198,16 @@ class DataspecTest(parameterized.TestCase):
     self.assertEqual(dataspec_lib.priority(None, 2), 2)
     self.assertIsNone(dataspec_lib.priority(None, None), None)
 
+  def test_to_proto_column_guide_escapes_regex(self):
+    self.assertEqual(
+        Column("a(z)e").to_proto_column_guide().column_name_pattern,
+        r"^a\(z\)e$",
+    )
+    self.assertEqual(
+        Column("user.age").to_proto_column_guide().column_name_pattern,
+        r"^user\.age$",
+    )
+
   def test_get_all_columns(self):
     self.assertEqual(
         dataspec_lib.get_all_columns(


### PR DESCRIPTION
## Bug

`Column.to_proto_column_guide()` generates the dataspec guide's `column_name_pattern` as:

```python
column_name_pattern=f"^{self.name}$"
```

In the C++ core, this pattern is matched with `std::regex_match(col_name, std::regex(pattern))` (`yggdrasil_decision_forests/dataset/data_spec_inference.cc`, `BuildColumnGuide`). Because the name is interpolated without escaping, any regex metacharacter in a column name breaks the match:

- `"user.age"` -> `^user.age$` matches `"userXage"` too, so a user-specified guide (e.g. a `Semantic` override) can silently apply to the wrong column.
- `"price($)"` -> `^price($)$` no longer matches the literal column name, so the user's feature specification is silently dropped.
- `"a[0]"` / `"col(1"` -> unbalanced brackets make `std::regex` throw during dataspec inference.

Column names containing dots, parentheses, or brackets are common in real datasets, and `features=["user.age", ...]` reaches this code path (see `DataSpecInferenceArgs.to_proto_guide`).

## Fix

Escape the column name with `re.escape`:

```python
column_name_pattern=f"^{re.escape(self.name)}$"
```

This is consistent with the existing helper `generic_learner._feature_name_to_regex`, which already returns `"^" + re.escape(name) + "$"` and is covered by `test_feature_name_to_regex`.

## Test

Added `test_to_proto_column_guide_escapes_regex` in `dataset/dataspec_test.py`, verifying `Column("a(z)e")` -> `^a\(z\)e$` and `Column("user.age")` -> `^user\.age$`.